### PR TITLE
Fix network::test_filter

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -41,6 +41,7 @@ pub(crate) fn get_arch_name() -> Option<&'static str> {
         "powerpc64" => Some("ppc64el"),
         "mips64" => Some("loongson3"),
         "riscv64" => Some("riscv64"),
+        "loongarch64" => Some("loongarch64"),
         _ => None,
     }
 }


### PR DESCRIPTION
Hi,

before the patch:

```
failures:

---- network::test_filter stdout ----
thread 'network::test_filter' panicked at 'called `Option::unwrap()` on a `None` value', src/network.rs:138:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    network::test_filter

test result: FAILED. 6 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

after:

```
running 7 tests
test network::test_filter ... ok
test parser::test_multi_package ... ok
test parser::test_key_value ... ok
test parser::test_key_name ... ok
test parser::test_single_line ... ok
test parser::test_seperator ... ok
test parser::test_package ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

Could you review the patch please?

Thanks,
Leslie Zhai